### PR TITLE
Fix NPE with null offsets

### DIFF
--- a/src/components/Consumer.vue
+++ b/src/components/Consumer.vue
@@ -52,7 +52,7 @@ export default {
           }
           _.forEach(partition.offsets, offset => {
             if (!isLabels) {
-              labels.push(utils.timestampShorten(offset.timestamp))
+              labels.push(utils.timestampShorten(offset === null ? 0 : offset.timestamp))
             }
 
             dataset.data.push(offset === null ? 0 : offset.lag)


### PR DESCRIPTION
burrow entries that are all null still cause:
Uncaught (in promise) TypeError: Cannot read property 'timestamp' of null
e.g.
{"offsets":[null,null,null,null,null],"owner":"kafka1","current-lag":0}